### PR TITLE
Use 'require_relative' in fib_test.rb

### DIFF
--- a/test/analyzer_sources/fib/fib_test.rb
+++ b/test/analyzer_sources/fib/fib_test.rb
@@ -1,13 +1,13 @@
 # Unit tests for fib.rb Ruby example.
 require 'minitest/unit'
-require './fib.rb'
+require_relative 'fib.rb'
 
 class FibTest < MiniTest::Unit::TestCase
   def test_base
     assert_equal 0, Fib.fib(0)
     assert_equal 1, Fib.fib(1)
   end
-  
+
   def test_easy
     assert_equal 1, Fib.fib(2)
     assert_equal 2, Fib.fib(3)
@@ -15,7 +15,7 @@ class FibTest < MiniTest::Unit::TestCase
     assert_equal 5, Fib.fib(5)
     assert_equal 8, Fib.fib(6)
   end
-  
+
   def test_medium
     assert_equal 144, Fib.fib(12)
     assert_equal 987, Fib.fib(16)
@@ -23,7 +23,7 @@ class FibTest < MiniTest::Unit::TestCase
     assert_equal 75025, Fib.fib(25)
     assert_equal 832040, Fib.fib(30)
   end
-  
+
   def test_hard
     assert_equal 354224848179261915075, Fib.fib(100)
     assert_equal 43466557686937456435688527675040625802564660517371780402481729089536555417949051890403879840079255169295922593080322634775209689623239873322471161642996440906533187938298969649928516003704476137795166849228875, Fib.fib(1000)

--- a/test/analyzer_sources/fib_grading/fib_test.rb
+++ b/test/analyzer_sources/fib_grading/fib_test.rb
@@ -1,13 +1,13 @@
 # Unit tests for fib.rb Ruby example.
 require 'minitest/unit'
-require './fib.rb'
+require_relative 'fib.rb'
 
 class FibTest < MiniTest::Unit::TestCase
   def test_base
     assert_equal 0, Fib.fib(0)
     assert_equal 1, Fib.fib(1)
   end
-  
+
   def test_easy
     assert_equal 1, Fib.fib(2)
     assert_equal 2, Fib.fib(3)
@@ -15,7 +15,7 @@ class FibTest < MiniTest::Unit::TestCase
     assert_equal 5, Fib.fib(5)
     assert_equal 8, Fib.fib(6)
   end
-  
+
   def test_medium
     assert_equal 144, Fib.fib(12)
     assert_equal 987, Fib.fib(16)
@@ -23,7 +23,7 @@ class FibTest < MiniTest::Unit::TestCase
     assert_equal 75025, Fib.fib(25)
     assert_equal 832040, Fib.fib(30)
   end
-  
+
   def test_hard
     assert_equal 354224848179261915075, Fib.fib(100)
     assert_equal 43466557686937456435688527675040625802564660517371780402481729089536555417949051890403879840079255169295922593080322634775209689623239873322471161642996440906533187938298969649928516003704476137795166849228875, Fib.fib(1000)


### PR DESCRIPTION
When I tried to run tests via `ruby test_file.rb` instead of `rake test test_file.rb`, I got a `LoadError` that pointed to these `fib_test.rb` files. It seems like maybe we want `require_relative` here anyway.
