### PR TITLE
Use edge Rails. Reconfigure minitest for spec DSL.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,13 @@
 source 'https://rubygems.org'
 
-gem 'rails', '>= 4.2.1'
+gem 'rails',
+    git: 'https://github.com/rails/rails', branch: 'master'
+
+gem 'sprockets-rails',
+    git: 'https://github.com/rails/sprockets-rails', branch: 'master'
+
+gem 'arel',
+    git: 'https://github.com/rails/arel', branch: 'master'
 
 gem 'mysql2', '>= 0.3.18'
 
@@ -61,7 +68,6 @@ group :development, :production do
 end
 
 group :development, :test do
-  gem 'minitest-rails', '>= 0'
   gem 'binary_fixtures', '>= 0.1.3'
   #gem 'turn', '>= 0.9.7'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,51 +5,90 @@ GIT
   specs:
     rack-noie (1.0)
 
-GEM
-  remote: https://rubygems.org/
+GIT
+  remote: https://github.com/rails/arel
+  revision: 7442623100f5ecdd73fd8f68376431762380f4e5
+  branch: master
   specs:
-    Ascii85 (1.0.2)
-    RedCloth (4.2.9)
-    actionmailer (4.2.1)
-      actionpack (= 4.2.1)
-      actionview (= 4.2.1)
-      activejob (= 4.2.1)
+    arel (7.0.0.alpha)
+
+GIT
+  remote: https://github.com/rails/rails
+  revision: ae5f2b4e79f3e41aad8280109d8bfc788a1a2733
+  branch: master
+  specs:
+    actionmailer (5.0.0.alpha)
+      actionpack (= 5.0.0.alpha)
+      actionview (= 5.0.0.alpha)
+      activejob (= 5.0.0.alpha)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 1.0, >= 1.0.5)
-    actionpack (4.2.1)
-      actionview (= 4.2.1)
-      activesupport (= 4.2.1)
+    actionpack (5.0.0.alpha)
+      actionview (= 5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
       rack (~> 1.6)
-      rack-test (~> 0.6.2)
+      rack-test (~> 0.6.3)
       rails-dom-testing (~> 1.0, >= 1.0.5)
-      rails-html-sanitizer (~> 1.0, >= 1.0.1)
-    actionview (4.2.1)
-      activesupport (= 4.2.1)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
       builder (~> 3.1)
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
-      rails-html-sanitizer (~> 1.0, >= 1.0.1)
-    activejob (4.2.1)
-      activesupport (= 4.2.1)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    activejob (5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
       globalid (>= 0.3.0)
-    activemodel (4.2.1)
-      activesupport (= 4.2.1)
+    activemodel (5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
       builder (~> 3.1)
-    activerecord (4.2.1)
-      activemodel (= 4.2.1)
-      activesupport (= 4.2.1)
-      arel (~> 6.0)
-    activesupport (4.2.1)
+    activerecord (5.0.0.alpha)
+      activemodel (= 5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      arel (= 7.0.0.alpha)
+    activesupport (5.0.0.alpha)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    rails (5.0.0.alpha)
+      actionmailer (= 5.0.0.alpha)
+      actionpack (= 5.0.0.alpha)
+      actionview (= 5.0.0.alpha)
+      activejob (= 5.0.0.alpha)
+      activemodel (= 5.0.0.alpha)
+      activerecord (= 5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      bundler (>= 1.3.0, < 2.0)
+      railties (= 5.0.0.alpha)
+      sprockets-rails
+    railties (5.0.0.alpha)
+      actionpack (= 5.0.0.alpha)
+      activesupport (= 5.0.0.alpha)
+      method_source
+      rake (>= 0.8.7)
+      thor (>= 0.18.1, < 2.0)
+
+GIT
+  remote: https://github.com/rails/sprockets-rails
+  revision: ae602d27bb951902d8b84bbde636cf11c66eae5a
+  branch: master
+  specs:
+    sprockets-rails (3.0.0.beta1)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0, < 4.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    Ascii85 (1.0.2)
+    RedCloth (4.2.9)
     afm (0.2.2)
-    annotate (2.6.8)
-      activerecord (>= 3.2, <= 4.3)
-      rake (~> 10.4)
-    arel (6.0.0)
+    annotate (2.6.7)
+      activerecord (>= 2.3.0)
+      rake (~> 10.4.2, >= 10.4.2)
     asciidoctor (1.5.2)
     authpwn_rails (0.17.2)
       rails (>= 4.0.9)
@@ -62,7 +101,7 @@ GEM
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
-    byebug (4.0.5)
+    byebug (5.0.0)
       columnize (= 0.9.0)
     climate_control (0.0.3)
       activesupport (>= 3.0)
@@ -115,8 +154,8 @@ GEM
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.2)
-    loofah (2.0.1)
+    json (1.8.3)
+    loofah (2.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
@@ -129,12 +168,10 @@ GEM
       pygments.rb (>= 0.5.2)
       redcarpet (>= 3.1.2)
       wikicloth (>= 0.8.1)
-    mime-types (2.4.3)
+    method_source (0.8.2)
+    mime-types (2.6.1)
     mini_portile (0.6.2)
-    minitest (5.6.0)
-    minitest-rails (2.1.1)
-      minitest (~> 5.4)
-      railties (~> 4.1)
+    minitest (5.7.0)
     mit_stalker (1.0.6)
     mysql2 (0.3.18)
     nokogiri (1.6.6.2)
@@ -164,21 +201,10 @@ GEM
     pygments.rb (0.6.3)
       posix-spawn (~> 0.3.6)
       yajl-ruby (~> 1.2.0)
-    rack (1.6.0)
+    rack (1.6.1)
     rack-test (0.6.3)
       rack (>= 1.0)
     railroady (1.3.0)
-    rails (4.2.1)
-      actionmailer (= 4.2.1)
-      actionpack (= 4.2.1)
-      actionview (= 4.2.1)
-      activejob (= 4.2.1)
-      activemodel (= 4.2.1)
-      activerecord (= 4.2.1)
-      activesupport (= 4.2.1)
-      bundler (>= 1.3.0, < 2.0)
-      railties (= 4.2.1)
-      sprockets-rails
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.6)
@@ -187,19 +213,13 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
-    railties (4.2.1)
-      actionpack (= 4.2.1)
-      activesupport (= 4.2.1)
-      rake (>= 0.8.7)
-      thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
     rdoc (4.2.0)
-      json (~> 1.4)
     redcarpet (3.2.3)
-    rmagick (2.14.0)
+    rmagick (2.15.2)
     ruby-rc4 (0.1.5)
     rubypants (0.2.0)
-    sass (3.4.13)
+    sass (3.4.14)
     sass-rails (5.0.3)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.1)
@@ -209,12 +229,8 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    sprockets (3.0.0)
+    sprockets (3.2.0)
       rack (~> 1.0)
-    sprockets-rails (2.2.4)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      sprockets (>= 2.8, < 4.0)
     thin (1.6.3)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0)
@@ -226,7 +242,7 @@ GEM
     trim_blobs (0.0.2)
       activerecord (>= 3.2.0)
     ttfunk (1.0.3)
-    twitter-text (1.11.0)
+    twitter-text (1.12.0)
       unf (~> 0.1.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -235,7 +251,7 @@ GEM
       json (>= 1.8.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.6)
+    unf_ext (0.0.7.1)
     wikicloth (0.8.3)
       builder
       expression_parser
@@ -250,6 +266,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate (>= 2.6.5)
+  arel!
   authpwn_rails (>= 0.17.2)
   better_errors
   binary_fixtures (>= 0.1.3)
@@ -269,7 +286,6 @@ DEPENDENCIES
   jquery-rails (>= 4.0.3)
   mail (>= 2.6.3)
   markdpwn (>= 0.2.0)
-  minitest-rails
   mit_stalker (>= 1.0.6)
   mysql2 (>= 0.3.18)
   nokogiri (>= 1.6.6.2)
@@ -280,10 +296,11 @@ DEPENDENCIES
   pwnstyles_rails (>= 0.2.1)
   rack-noie (>= 1.0)!
   railroady (>= 1.3.0)
-  rails (>= 4.2.1)
+  rails!
   rmagick (>= 2.14.0)
   sass-rails (>= 5.0.3)
   sdoc
+  sprockets-rails!
   thin (>= 1.6.3)
   trim_blobs
   uglifier (>= 2.7.0)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ plugin. Re-generate them using the following command.
 bundle exec annotate
 ```
 
+Updating the bundled gems requires bundler 1.9 for now. Bundler 1.10 breaks for
+some reason that we don't want to look into.
+
+```bash
+gem uninstall bundler --all
+gem install bundler --version '~> 1.9.9'
+```
+
 
 ## Production Deployment on alg.csail.mit.edu
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
-require 'minitest/rails'
+require 'minitest/spec'
 
 #require 'turn'
 
@@ -19,5 +19,5 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+  extend MiniTest::Spec::DSL
 end
-


### PR DESCRIPTION
Rails v4.2.1 has a bug which fails to load fixtures for models that extend an abstract class, if the abstract class defines belongs_to associations. An alternative is to redefine those associations in each of the concrete classes, which is not DRY.
