### PR TITLE
Change abstract class RoleBase to an AS::Concern.

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,9 +1,8 @@
 require 'set'
 
 # A privilege granted to an user.
-class Role < RoleBase
-  # Needed because we're not using STI.
-  self.table_name = 'roles'
+class Role < ActiveRecord::Base
+  include RoleBase
 
   # Checks if a user has a privilege.
   def self.has_entry?(user, role_name, course = nil)

--- a/app/models/role_request.rb
+++ b/app/models/role_request.rb
@@ -1,7 +1,6 @@
 # A request by a user to receive a privilege.
-class RoleRequest < RoleBase
-  # Needed because we're not using STI.
-  self.table_name = 'role_requests'
+class RoleRequest < ActiveRecord::Base
+  include RoleBase
 
   # Creates the Role referred to by this request.
   def approve


### PR DESCRIPTION
Recent versions of Rails 4 lost support for loading fixtures for models that extend an abstract class if the abstract class has `belongs_to` associations. Using AS::Concern modules lets us continue to use fixtures for Role and RoleRequest, which share the RoleBase functionality.
