### PR TITLE
Remove deprecation errors for edge Rails.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,8 +21,5 @@ module Seven
     # config.i18n.default_locale = :de
 
     config.active_job.queue_adapter = :delayed_job
-
-    # Propagate errors raised within `after_rollback/after_commit` callbacks.
-    config.active_record.raise_in_transactional_callbacks = true
   end
 end


### PR DESCRIPTION
Run tests and get

```
DEPRECATION WARNING: ActiveRecord::Base.raise_in_transactional_callbacks= is deprecated, has no effect and will be removed without replacement.
```
