### PR TITLE
Fix assignment dashboard 500 error.

### DIFF
--- a/app/helpers/icons_helper.rb
+++ b/app/helpers/icons_helper.rb
@@ -1,5 +1,7 @@
 # Methods for rendering generic UI icons.
 module IconsHelper
+  include AnalysesHelper  # For analysis_status_text.
+
   # Tells the user that his input is valid.
   def valid_icon_tag
     title = 'Valid input'

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -1,4 +1,7 @@
 module SubmissionsHelper
+  include UsersHelper  # For user_image_tag.
+  include IconsHelper  # For analysis_status_icon_tag.
+
   # The submission's promoted state in text, or a button to promote it.
   def submission_promotion_status(submission, user)
     if submission == submission.deliverable.submission_for_grading(user)
@@ -28,5 +31,17 @@ module SubmissionsHelper
   # Text that identifies the collaborator in the collaboration.
   def collaborator_display_name(collaborator)
     "#{collaborator.email} (#{collaborator.profile.name})"
+  end
+
+  # An icon that links to the given submission's analysis, if one exists.
+  def submission_figure(submission)
+    analysis = submission.analysis
+    if analysis
+      link_to analysis_path(analysis, course_id: submission.course) do
+        render 'deliverables/submission_figure', submission: submission
+      end
+    else
+      render 'deliverables/submission_figure', submission: submission
+    end
   end
 end

--- a/app/views/deliverables/_submission_figure.html.erb
+++ b/app/views/deliverables/_submission_figure.html.erb
@@ -1,0 +1,4 @@
+<figure title="<%= submission.subject.name %>">
+  <%= user_image_tag submission.subject, size: :large %>
+  <%= analysis_status_icon_tag submission.analysis %>
+</figure>

--- a/app/views/deliverables/_submission_list.html.erb
+++ b/app/views/deliverables/_submission_list.html.erb
@@ -1,16 +1,9 @@
-<% submissions = deliverable.submissions.
-      includes([:analysis, { subject: [ :credentials, { profile: :photo } ] }]).
-      order(updated_at: :desc) %>
+<% submissions = deliverable.submissions.includes(:analysis, :subject).
+                                         order(updated_at: :desc) %>
 <ol class="submission-list">
   <% submissions.each do |submission| %>
   <li>
-    <%= link_to polymorphic_url(submission.analysis || submission,
-                                course_id: submission.course) do %>
-      <figure title="<%= submission.subject.name %>">
-        <%= user_image_tag submission.subject, size: :large %>
-        <%= analysis_status_icon_tag submission.analysis %>
-      </figure>
-    <% end %>
+    <%= submission_figure submission %>
   </li>
 <% end %>
 <% if submissions.any? { |s| s.analysis && s.analysis.status_will_change? } %>

--- a/test/fixtures/analyses.yml
+++ b/test/fixtures/analyses.yml
@@ -12,8 +12,41 @@
 #  updated_at    :datetime         not null
 #
 
+# NOTE: Do not create an analysis for the submissions(:solo_ps1) fixture, so
+#     that it can be built in model tests.
+
+dexter_ps1:
+  submission: dexter_ps1
+  status_code: 7
+  log: ''
+  private_log: ''
+
+dexter_project:
+  submission: dexter_project
+  status_code: 7
+  log: ''
+  private_log: ''
+
+dexter_project_v2:
+  submission: dexter_project_v2
+  status_code: 7
+  log: ''
+  private_log: ''
+
+mandark_project:
+  submission: mandark_project
+  status_code: 7
+  log: ''
+  private_log: ''
+
 dexter_assessment:
   submission: dexter_assessment
+  status_code: 2
+  log: ''
+  private_log: ''
+
+deedee_assessment:
+  submission: deedee_assessment
   status_code: 2
   log: ''
   private_log: ''
@@ -24,8 +57,8 @@ dexter_code:
   log: ''
   private_log: ''
 
-deedee_assessment:
-  submission: deedee_assessment
+dexter_code_v2:
+  submission: dexter_code_v2
   status_code: 2
   log: ''
   private_log: ''

--- a/test/helpers/submissions_helper_test.rb
+++ b/test/helpers/submissions_helper_test.rb
@@ -4,6 +4,7 @@ class SubmissionsHelperTest < ActionView::TestCase
   include SubmissionsHelper
 
   let(:submission) { submissions(:dexter_assessment) }
+  let(:analysis) { submission.analysis }
 
   describe '#new_collaboration' do
     let(:invalid_collaboration) do
@@ -37,6 +38,29 @@ class SubmissionsHelperTest < ActionView::TestCase
         result = new_collaboration(invalid_collaboration, submission)
         assert_instance_of Collaboration, result
         assert_equal 'nosuchuser@gmail.com', result.collaborator_email
+      end
+    end
+  end
+
+  describe '#submission_figure' do
+    describe 'the submission has an analysis' do
+      before { assert_not_nil analysis }
+      let(:url) { analysis_path(analysis, course_id: analysis.course) }
+
+      it 'renders the submission figure inside a link to the analysis' do
+        rendered_buffer = render text: submission_figure(submission)
+        assert_select 'a[href=?]', url, true, rendered_buffer do
+          assert_select 'figure'
+        end
+      end
+    end
+
+    describe 'the submission does not have an analysis' do
+      before { submission.analysis.destroy }
+
+      it 'renders the submission figure without crashing' do
+        rendered_buffer = render text: submission_figure(submission.reload)
+        assert_select 'figure', true, rendered_buffer
       end
     end
   end


### PR DESCRIPTION
`Team` submissions don't have `:credentials` and profile photos.
`Submission` fixtures without an associated `Analysis` break the analysis link.