### PR TITLE
Darken form input color.

### DIFF
--- a/app/assets/stylesheets/foundation_and_overrides.scss
+++ b/app/assets/stylesheets/foundation_and_overrides.scss
@@ -331,7 +331,7 @@ $form-label-line-height: 1.8;
 $select-background: #fafafa;
 $select-triangle-color: #333;
 $select-radius: $global-radius;
-$input-color: $dark-gray;
+$input-color: $black;  // $dark-gray;
 $input-font-family: inherit;
 $input-font-size: rem-calc(16);
 $input-background: $white;


### PR DESCRIPTION
I think when it's completely black, it looks a little out of place, since the input border is a bit gray too. So I just made our custom `$very-dark-gray` color, which was previously used to color the comments in the grade editor, even darker, and used that.