### PR TITLE
Remove seconds from datetime_local_field inputs.

### DIFF
--- a/app/views/assignment_files/_fields.html.erb
+++ b/app/views/assignment_files/_fields.html.erb
@@ -48,7 +48,7 @@
       <%= f.label :published_at, 'Release date', class: 'text-right middle' %>
     </div>
     <div class="small-6 columns">
-      <%= f.datetime_local_field :published_at, step: 900, required: true %>
+      <%= f.datetime_local_field :published_at, required: true %>
     </div>
   </div>
 </section>

--- a/app/views/assignments/_fields.html.erb
+++ b/app/views/assignments/_fields.html.erb
@@ -13,7 +13,7 @@
     <%= f.label :published_at, 'Release Date/Time', class: 'text-right middle' %>
   </div>
   <div class="small-6 columns">
-    <%= f.datetime_local_field :published_at, step: 900, data: {
+    <%= f.datetime_local_field :published_at, data: {
           pwnfx_scope: 'publish', pwnfx_disable_positive: 'publish-p' } %>
   </div>
   <div class="small-3 columns">

--- a/app/views/submissions/_request_assignment.html.erb
+++ b/app/views/submissions/_request_assignment.html.erb
@@ -35,7 +35,7 @@
         <span class="query-input-field"
               data-pwnfx-move-target="submission-cutoff-deadline">
           <%= datetime_local_field_tag :submission_cutoff,
-                Time.current.to_s(:datetime_local_field), step: 900 %>
+                Time.current.to_s(:datetime_local_field) %>
         </span>
       </div>
     </section>

--- a/app/views/submissions/_xhr_deliverables.html.erb
+++ b/app/views/submissions/_xhr_deliverables.html.erb
@@ -15,5 +15,5 @@
 <span data-pwnfx-move="submission-cutoff-deadline"
       data-pwnfx-move-method="replace" data-pwnfx-scope="grading-kit">
   <%= datetime_local_field_tag :submission_cutoff,
-        assignment.due_at.to_s(:datetime_local_field), step: 900 %>
+        assignment.due_at.to_s(:datetime_local_field) %>
 </span>

--- a/app/views/surveys/_fields.html.erb
+++ b/app/views/surveys/_fields.html.erb
@@ -13,6 +13,6 @@
     <%= f.label :due_at, 'Response Deadline', class: 'text-right middle' %>
   </div>
   <div class="small-6 columns">
-    <%= f.datetime_local_field :due_at, step: 900 %>
+    <%= f.datetime_local_field :due_at %>
   </div>
 </div>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,5 +1,5 @@
 Time::DATE_FORMATS.merge!(
-  datetime_local_field: '%Y-%m-%dT%I:%M:%S',
+  datetime_local_field: '%Y-%m-%dT%I:%M',
   deadline_short: '%b %e',
   deadline_long: '%a %b %e, %l:%M%p',
   extension_long: '%m/%d/%y, %l:%M %p',

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -158,6 +158,8 @@ puts 'Surveys created'
 
 # Exams.
 
+base_time = Time.current.beginning_of_minute
+
 exam_data = [
   { due_at: -6.weeks - 5.days, grades_published: true, state: :graded },
   { due_at: -5.days, grades_published: false, state: :grading },
@@ -169,7 +171,7 @@ exams = exam_data.map.with_index do |data, index|
 
   exam = Assignment.new name: "Exam #{i}", weight: 5.0, author: admin
   exam.course = course
-  exam.build_deadline due_at: (Time.current + data[:due_at]), course: course
+  exam.build_deadline due_at: (base_time + data[:due_at]), course: course
   exam.published_at = exam.due_at - 1.week
   exam.grades_published = data[:grades_published]
   exam.save!
@@ -182,7 +184,7 @@ end
 
 students.each_with_index do |user, i|
   exams.each_with_index do |exam, j|
-    next unless exam.due_at < Time.current
+    next unless exam.due_at < base_time
     exam.metrics.each.with_index do |metric, k|
       next if i + j == k
       grade = metric.grades.build subject: user,
@@ -219,7 +221,7 @@ psets = pset_data.map.with_index do |data, index|
   i = index + 1
   pset = Assignment.new name: "Problem Set #{i}", weight: 1.0, author: admin
   pset.course = course
-  pset.build_deadline due_at: (Time.current + data[:due_at]), course: course
+  pset.build_deadline due_at: (base_time + data[:due_at]), course: course
   pset.published_at = pset.due_at - 1.week
   pset.grades_published = data[:grades_published]
   pset.save!
@@ -243,7 +245,7 @@ end
 
 ([admin] + students).each_with_index do |user, i|
   psets.each_with_index do |pset, j|
-    next unless pset.due_at < Time.current
+    next unless pset.due_at < base_time
 
     unless (i + j) % 20 == 1
       # Submit PDF.


### PR DESCRIPTION
Now, as long as you don't have existing records with datetime fields that have values other than `0` for the seconds-level granularity, the seconds field won't even show up. Current database records in prod probably use seconds, so the seconds field will still show up in gray, but new records should work without seconds.