### PR TITLE
Add null: false to all timestamps.

### DIFF
--- a/db/migrate/20100725000001_create_users.rb
+++ b/db/migrate/20100725000001_create_users.rb
@@ -3,7 +3,7 @@ class CreateUsers < ActiveRecord::Migration
     create_table :users do |t|
       t.string :exuid, limit: 32, null: false
 
-      t.timestamps
+      t.timestamps null: false
     end
 
     add_index :users, :exuid, unique: true

--- a/db/migrate/20110704010001_create_roles.rb
+++ b/db/migrate/20110704010001_create_roles.rb
@@ -5,7 +5,7 @@ class CreateRoles < ActiveRecord::Migration
       t.string :name, limit: 8, null: false
       t.references :course
 
-      t.timestamps
+      t.timestamps null: false
     end
 
     # List all staff members in a course. Prevent duplicate role entries.

--- a/db/migrate/20110704010002_create_profiles.rb
+++ b/db/migrate/20110704010002_create_profiles.rb
@@ -9,7 +9,7 @@ class CreateProfiles < ActiveRecord::Migration
       t.string :year, null: false, limit: 4
       t.string :athena_username, null: false, limit: 32
 
-      t.timestamps
+      t.timestamps null: false
     end
 
     add_index :profiles, :user_id, unique: true

--- a/db/migrate/20110704010003_create_profile_photos.rb
+++ b/db/migrate/20110704010003_create_profile_photos.rb
@@ -2,7 +2,7 @@ class CreateProfilePhotos < ActiveRecord::Migration
   def change
     create_table :profile_photos do |t|
       t.references :profile, null: false
-      t.timestamps
+      t.timestamps null: false
     end
 
     add_attachment :profile_photos, :pic

--- a/db/migrate/20110704010006_create_role_requests.rb
+++ b/db/migrate/20110704010006_create_role_requests.rb
@@ -5,7 +5,7 @@ class CreateRoleRequests < ActiveRecord::Migration
       t.string :name, limit: 8, null: false
       t.references :course
 
-      t.timestamps
+      t.timestamps null: false
     end
 
     # List all requests in a course. Prevent duplicate requests.

--- a/db/migrate/20110704020001_create_courses.rb
+++ b/db/migrate/20110704020001_create_courses.rb
@@ -11,7 +11,7 @@ class CreateCourses < ActiveRecord::Migration
       t.boolean :has_teams, null: false
       t.integer :section_size, null: true
 
-      t.timestamps
+      t.timestamps null: false
     end
 
     # Enforce course number uniqueness.

--- a/db/migrate/20110704020003_create_prerequisites.rb
+++ b/db/migrate/20110704020003_create_prerequisites.rb
@@ -5,7 +5,7 @@ class CreatePrerequisites < ActiveRecord::Migration
       t.string :prerequisite_number, limit: 64, null: false
       t.string :waiver_question, limit: 256, null: false
 
-      t.timestamps
+      t.timestamps null: false
     end
 
     add_index :prerequisites, [:course_id, :prerequisite_number], unique: true

--- a/db/migrate/20110704020004_create_registrations.rb
+++ b/db/migrate/20110704020004_create_registrations.rb
@@ -10,7 +10,7 @@ class CreateRegistrations < ActiveRecord::Migration
       # TODO: move this to some partition class.
       t.references :recitation_section, null: true
 
-      t.timestamps
+      t.timestamps null: false
     end
 
     add_index :registrations, [:user_id, :course_id], unique: true

--- a/db/migrate/20110704020006_create_prerequisite_answers.rb
+++ b/db/migrate/20110704020006_create_prerequisite_answers.rb
@@ -6,7 +6,7 @@ class CreatePrerequisiteAnswers < ActiveRecord::Migration
       t.boolean :took_course, null: false
       t.text :waiver_answer, limit: 4.kilobytes
 
-      t.timestamps
+      t.timestamps null: false
     end
 
     # Optimize getting prerequisite answers for a registration.

--- a/db/migrate/20110704030001_create_deadline_extensions.rb
+++ b/db/migrate/20110704030001_create_deadline_extensions.rb
@@ -6,7 +6,7 @@ class CreateDeadlineExtensions < ActiveRecord::Migration
       t.references :grantor, null: true
       t.datetime :due_at, null: false
 
-      t.timestamps
+      t.timestamps null: false
 
       t.index [:subject_id, :subject_type, :user_id], unique: true,
           name: 'index_deadline_extensions_on_subject_and_user_id'

--- a/db/migrate/20110704030002_create_assignments.rb
+++ b/db/migrate/20110704030002_create_assignments.rb
@@ -10,7 +10,7 @@ class CreateAssignments < ActiveRecord::Migration
       t.decimal :weight, precision: 16, scale: 8, null: false
       t.references :team_partition, null: true
 
-      t.timestamps
+      t.timestamps null: false
 
       t.index [:course_id, :released_at, :name], unique: true
       t.index [:course_id, :name], unique: true

--- a/db/migrate/20110704030003_create_assignment_files.rb
+++ b/db/migrate/20110704030003_create_assignment_files.rb
@@ -7,7 +7,7 @@ class CreateAssignmentFiles < ActiveRecord::Migration
                              null: false
       t.datetime :released_at, null: true
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/db/migrate/20110704030004_create_assignment_metrics.rb
+++ b/db/migrate/20110704030004_create_assignment_metrics.rb
@@ -6,7 +6,7 @@ class CreateAssignmentMetrics < ActiveRecord::Migration
       t.integer :max_score, null: false
       t.decimal :weight, precision: 16, scale: 8, null: false
 
-      t.timestamps
+      t.timestamps null: false
 
       t.index [:assignment_id, :name], unique: true
     end

--- a/db/migrate/20110704030005_create_grades.rb
+++ b/db/migrate/20110704030005_create_grades.rb
@@ -8,7 +8,7 @@ class CreateGrades < ActiveRecord::Migration
       t.references :subject, polymorphic: { limit: 64 }, null: false
       t.decimal :score, precision: 8, scale: 2, null: false
 
-      t.timestamps
+      t.timestamps null: false
 
       # Get grades for a user/team.
       t.index [:subject_id, :subject_type, :metric_id], unique: true

--- a/db/migrate/20110704030006_create_grade_comments.rb
+++ b/db/migrate/20110704030006_create_grade_comments.rb
@@ -7,7 +7,7 @@ class CreateGradeComments < ActiveRecord::Migration
       t.references :subject, polymorphic: { limit: 16 }, null: false
       t.text :text, limit: 4.kilobytes, null: false
 
-      t.timestamps
+      t.timestamps null: false
 
       # Get comments for a user/team.
       t.index [:subject_id, :subject_type, :metric_id], unique: true,

--- a/db/migrate/20110704040001_create_deliverables.rb
+++ b/db/migrate/20110704040001_create_deliverables.rb
@@ -6,7 +6,7 @@ class CreateDeliverables < ActiveRecord::Migration
       t.string :name, limit: 80, null: false
       t.string :description, limit: 2.kilobytes, null: false
 
-      t.timestamps
+      t.timestamps null: false
     end
 
     add_index :deliverables, [:assignment_id, :name], unique: true

--- a/db/migrate/20110704040002_create_analyzers.rb
+++ b/db/migrate/20110704040002_create_analyzers.rb
@@ -11,7 +11,7 @@ class CreateAnalyzers < ActiveRecord::Migration
 
       t.string :message_name, limit: 64, null: true
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/db/migrate/20110704040003_create_submissions.rb
+++ b/db/migrate/20110704040003_create_submissions.rb
@@ -7,7 +7,7 @@ class CreateSubmissions < ActiveRecord::Migration
       t.references :uploader, null: false
       t.string :upload_ip, limit: 48, null: false
 
-      t.timestamps
+      t.timestamps null: false
 
       t.index [:subject_id, :subject_type, :deliverable_id], unique: false,
           name: 'index_submissions_on_subject_id_and_type_and_deliverable_id'

--- a/db/migrate/20110704040005_create_analyses.rb
+++ b/db/migrate/20110704040005_create_analyses.rb
@@ -8,7 +8,7 @@ class CreateAnalyses < ActiveRecord::Migration
       t.text :private_log, limit: 64.kilobytes, null: false
       t.text :scores, limit: 16.kilobytes, null: true
 
-      t.timestamps
+      t.timestamps null: false
 
       t.index :submission_id, unique: true
     end

--- a/db/migrate/20110704050001_create_surveys.rb
+++ b/db/migrate/20110704050001_create_surveys.rb
@@ -5,7 +5,7 @@ class CreateSurveys < ActiveRecord::Migration
       t.boolean :released, null: false
       t.references :course, null: false
 
-      t.timestamps
+      t.timestamps null: false
 
       t.index [:course_id, :name], unique: true
     end

--- a/db/migrate/20110704050002_create_survey_questions.rb
+++ b/db/migrate/20110704050002_create_survey_questions.rb
@@ -7,7 +7,7 @@ class CreateSurveyQuestions < ActiveRecord::Migration
       t.string :type, limit: 32, null: false
       t.text :features, null: false
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/db/migrate/20110704050003_create_survey_responses.rb
+++ b/db/migrate/20110704050003_create_survey_responses.rb
@@ -5,7 +5,7 @@ class CreateSurveyResponses < ActiveRecord::Migration
       t.references :user, null: false
       t.references :survey, null: false
 
-      t.timestamps
+      t.timestamps null: false
 
       # Get a user's response to a survey.
       t.index [:user_id, :survey_id], unique: true

--- a/db/migrate/20110704050004_create_survey_answers.rb
+++ b/db/migrate/20110704050004_create_survey_answers.rb
@@ -6,7 +6,7 @@ class CreateSurveyAnswers < ActiveRecord::Migration
       t.decimal :number, null: true, precision: 7, scale: 2
       t.string :comment, limit: 1.kilobyte, null: true
 
-      t.timestamps
+      t.timestamps null: false
 
       t.index [:response_id, :question_id], unique: true
     end

--- a/db/migrate/20110704060001_create_team_partitions.rb
+++ b/db/migrate/20110704060001_create_team_partitions.rb
@@ -10,7 +10,7 @@ class CreateTeamPartitions < ActiveRecord::Migration
       t.boolean :editable, null: false, default: true
       t.boolean :released, null: false, default: false
 
-      t.timestamps
+      t.timestamps null: false
 
       t.index [:course_id, :name], unique: true
     end

--- a/db/migrate/20110704060002_create_teams.rb
+++ b/db/migrate/20110704060002_create_teams.rb
@@ -4,7 +4,7 @@ class CreateTeams < ActiveRecord::Migration
       t.references :partition, null: false
       t.string :name, limit: 64, null: false
 
-      t.timestamps
+      t.timestamps null: false
     end
 
     # Prevent duplicate names in a partition.

--- a/db/migrate/20110704060004_create_invitations.rb
+++ b/db/migrate/20110704060004_create_invitations.rb
@@ -5,7 +5,7 @@ class CreateInvitations < ActiveRecord::Migration
       t.integer :invitee_id
       t.integer :team_id
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/db/migrate/20110704060005_create_recitation_sections.rb
+++ b/db/migrate/20110704060005_create_recitation_sections.rb
@@ -6,7 +6,7 @@ class CreateRecitationSections < ActiveRecord::Migration
       t.integer :serial, null: false
       t.string :location, limit: 64, null: false
 
-      t.timestamps
+      t.timestamps null: false
 
       t.index [:course_id, :serial], unique: true
     end

--- a/db/migrate/20110704070001_create_announcements.rb
+++ b/db/migrate/20110704070001_create_announcements.rb
@@ -7,7 +7,7 @@ class CreateAnnouncements < ActiveRecord::Migration
       t.string :contents, limit: 8.kilobytes, null: false
       t.boolean :open_to_visitors, null: false, default: false
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/db/migrate/20110704080003_create_exam_attendances.rb
+++ b/db/migrate/20110704080003_create_exam_attendances.rb
@@ -6,7 +6,7 @@ class CreateExamAttendances < ActiveRecord::Migration
       t.references :exam_session, foreign_key: true, null: false
       t.boolean :confirmed, null: false
 
-      t.timestamps
+      t.timestamps null: false
 
       t.index [:exam_id, :user_id], unique: true
       t.index [:exam_session_id, :user_id], unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -163,8 +163,8 @@ ActiveRecord::Schema.define(version: 20110704080003) do
     t.datetime "failed_at"
     t.string   "locked_by"
     t.string   "queue"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
   end
 


### PR DESCRIPTION
Seems like the default `null: false` condition for timestamps was lost at some point. If you run migrations in master, the `schema.rb` file loses all of the `NOT NULL` statements for timestamp fields. Explicitly stating it in the migrations should help us avoid churn in the `schema.rb` in the future.