### PR TITLE
Upgrade "annotate" gem and add missing annotations.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,10 +88,7 @@ end
 group :development do
   gem 'web-console', '>= 3.5.0'
   gem 'binding_of_caller', '>= 0.7.3.pre1'
-  # TODO(pwnall): Remove the git ref when 2.7.2 gets released.
-  gem 'annotate', '>= 2.7.1',
-      git: 'https://github.com/ctran/annotate_models.git',
-      ref: '983d36f6a028daa289f31c0fe3fa83df36825d25'
+  gem 'annotate', '>= 2.7.2'
   # TODO(pwnall): Remove version limitation when the rake issue gets fixed.
   #               https://github.com/stympy/faker/issues/780
   gem 'faker', ['>= 1.6.6', '< 1.7']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/ctran/annotate_models.git
-  revision: 983d36f6a028daa289f31c0fe3fa83df36825d25
-  ref: 983d36f6a028daa289f31c0fe3fa83df36825d25
-  specs:
-    annotate (2.7.1)
-      activerecord (>= 3.2, < 6.0)
-      rake (>= 10.4, < 12.1)
-
-GIT
   remote: https://github.com/jruby/activerecord-jdbc-adapter.git
   revision: 468c57adc765a513b8ae400b2b171e318e159bd2
   specs:
@@ -57,6 +48,9 @@ GEM
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     afm (0.2.2)
+    annotate (2.7.2)
+      activerecord (>= 3.2, < 6.0)
+      rake (>= 10.4, < 13.0)
     arel (8.0.0)
     asciidoctor (1.5.6.1)
     authpwn_rails (0.23.0)
@@ -334,7 +328,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter!
-  annotate (>= 2.7.1)!
+  annotate (>= 2.7.2)
   authpwn_rails (>= 0.22.0)
   autoprefixer-rails (>= 7.1.2.3)
   bigdecimal (>= 1.3.1)
@@ -400,4 +394,4 @@ RUBY VERSION
    ruby 2.4.0p0
 
 BUNDLED WITH
-   1.14.6
+   1.15.4

--- a/test/fixtures/analyzers.yml
+++ b/test/fixtures/analyzers.yml
@@ -2,15 +2,18 @@
 #
 # Table name: analyzers
 #
-#  id             :integer          not null, primary key
-#  deliverable_id :integer          not null
-#  type           :string(32)       not null
-#  auto_grading   :boolean          not null
-#  exec_limits    :text
-#  db_file_id     :integer
-#  message_name   :string(64)
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
+#  id                 :integer          not null, primary key
+#  deliverable_id     :integer          not null
+#  type               :string(32)       not null
+#  auto_grading       :boolean          not null
+#  exec_limits        :text
+#  file_blob_id       :string(48)
+#  file_size          :integer
+#  file_mime_type     :string(64)
+#  file_original_name :string(256)
+#  message_name       :string(64)
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
 #
 
 proc_ps1_writeup:

--- a/test/fixtures/assignment_files.yml
+++ b/test/fixtures/assignment_files.yml
@@ -2,13 +2,16 @@
 #
 # Table name: assignment_files
 #
-#  id            :integer          not null, primary key
-#  description   :string(64)       not null
-#  assignment_id :integer          not null
-#  db_file_id    :integer          not null
-#  released_at   :datetime
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id                 :integer          not null, primary key
+#  description        :string(64)       not null
+#  assignment_id      :integer          not null
+#  file_blob_id       :string(48)       not null
+#  file_size          :integer          not null
+#  file_mime_type     :string(64)       not null
+#  file_original_name :string(256)      not null
+#  released_at        :datetime
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
 #
 
 ps1_solutions:

--- a/test/fixtures/file_blobs.yml
+++ b/test/fixtures/file_blobs.yml
@@ -1,3 +1,11 @@
+# == Schema Information
+#
+# Table name: file_blobs
+#
+#  id   :string(48)       not null, primary key
+#  data :binary           not null
+#
+
 small_pdf:
   id: <%= file_blob_id 'files/submission/small.pdf' %>
   data: <%= file_blob_data 'files/submission/small.pdf' %>

--- a/test/fixtures/grade_comments.yml
+++ b/test/fixtures/grade_comments.yml
@@ -6,7 +6,7 @@
 #  course_id    :integer          not null
 #  metric_id    :integer          not null
 #  grader_id    :integer          not null
-#  subject_type :string(16)
+#  subject_type :string(16)       not null
 #  subject_id   :integer          not null
 #  text         :text             not null
 #  created_at   :datetime         not null

--- a/test/fixtures/grades.yml
+++ b/test/fixtures/grades.yml
@@ -6,7 +6,7 @@
 #  course_id    :integer          not null
 #  metric_id    :integer          not null
 #  grader_id    :integer          not null
-#  subject_type :string(64)
+#  subject_type :string(64)       not null
 #  subject_id   :integer          not null
 #  score        :decimal(8, 2)    not null
 #  created_at   :datetime         not null

--- a/test/fixtures/profile_photos.yml
+++ b/test/fixtures/profile_photos.yml
@@ -1,13 +1,14 @@
+
 # == Schema Information
 #
 # Table name: profile_photos
 #
-#  id               :integer          not null, primary key
-#  profile_id       :integer          not null
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  pic_file_name    :string
-#  pic_content_type :string
-#  pic_file_size    :integer
-#  pic_updated_at   :datetime
+#  id                  :integer          not null, primary key
+#  profile_id          :integer          not null
+#  image_blob_id       :string(48)       not null
+#  image_size          :integer          not null
+#  image_mime_type     :string(64)       not null
+#  image_original_name :string(256)      not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
 #

--- a/test/fixtures/submissions.yml
+++ b/test/fixtures/submissions.yml
@@ -2,15 +2,18 @@
 #
 # Table name: submissions
 #
-#  id             :integer          not null, primary key
-#  deliverable_id :integer          not null
-#  db_file_id     :integer          not null
-#  subject_type   :string           not null
-#  subject_id     :integer          not null
-#  uploader_id    :integer          not null
-#  upload_ip      :string(48)       not null
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
+#  id                 :integer          not null, primary key
+#  deliverable_id     :integer          not null
+#  file_blob_id       :string(48)       not null
+#  file_size          :integer          not null
+#  file_mime_type     :string(64)       not null
+#  file_original_name :string(256)      not null
+#  subject_type       :string           not null
+#  subject_id         :integer          not null
+#  uploader_id        :integer          not null
+#  upload_ip          :string(48)       not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
 #
 
 # NOTE: Do not create a submissions for the following:


### PR DESCRIPTION
This change upgrades our `annotate` gem to a version which also fixes a bug where the annotation rake task wouldn't automatically run with `rake db:migrate` (https://github.com/ctran/annotate_models/pull/448). The results of re-running migrations are included here.